### PR TITLE
Switch direct deps to peer dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+fixtures

--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@
 
 `yarn add -D @jbateson/eslint-config`
 
-In .eslintrc:
+And make sure you install the required peer dependencies required for this config:
 
 ```
+$ yarn global add install-peerdeps
+$ install-peerdeps @jbateson/eslint-config
+```
+
+In .eslintrc:
+
+```json
 {
     "extends": "@jbateson"
 }

--- a/fixtures/.eslintrc.js
+++ b/fixtures/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@jbateson/eslint-config/index.js');

--- a/fixtures/my_cool_file.js
+++ b/fixtures/my_cool_file.js
@@ -1,0 +1,5 @@
+function foo() {
+  console.log("hello world");
+}
+
+foo();

--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "test-consumer",
+    "version": "1.0.0",
+    "scripts": {
+        "lint": "eslint ."
+    }
+}

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,45 @@
+const path = require('path');
+
+const cpy = require('cpy');
+const shell = require('shelljs');
+const tmp = require('tmp');
+const execute = require('install-local').execute;
+
+it('installs with peer deps and lints', done => {
+  tmp.dir({ unsafeCleanup: true }, async function _tempDirCreated(
+    err,
+    dir,
+    cleanupCallback,
+  ) {
+    if (err) throw err;
+
+    await cpy(path.join(__dirname, 'fixtures/**/{.*,*}'), dir);
+
+    shell.cd(dir);
+
+    // Install our peer deps to simulate how a real consumer of this package
+    // would do so. In reality they'd likely use `install-peerdeps`, but the
+    // behaviour is the same.
+    const peerDeps = require(`${__dirname}/package.json`).peerDependencies;
+    const installString = Object.entries(peerDeps)
+      .map(([name, version]) => `${name}@${version}`)
+      .join(' ');
+    console.log(installString);
+    shell.exec(`npm install ${installString}`);
+
+    // Now install the package itself
+    await execute({
+      dependencies: [__dirname],
+      save: true,
+      targetSiblings: false,
+    });
+
+    // This is a run script defined in our fixture's package.json
+    const lintResult = shell.exec('npm run lint');
+    expect(lintResult.code).toEqual(0);
+
+    // Manual cleanup
+    cleanupCallback();
+    done();
+  });
+}, 60000);

--- a/package.json
+++ b/package.json
@@ -12,18 +12,17 @@
     "test": "eslint --fix .",
     "release": "semantic-release"
   },
-  "dependencies": {
-    "babel-eslint": "^10.0.1",
+  "peerDependencies": {
+    "babel-eslint": "9.x",
     "eslint": "5.x",
     "eslint-config-prettier": "^4.0.0",
-    "eslint-config-react-app": "^3.0.7",
-    "eslint-plugin-flowtype": "^3.4.2",
+    "eslint-config-react-app": "^3.0.8",
+    "eslint-plugin-flowtype": "^2.x",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-hooks": "1.x",
-    "lint-staged": "^8.1.4",
     "prettier": "^1.16.4"
   },
   "repository": {
@@ -36,7 +35,19 @@
   ],
   "devDependencies": {
     "@jbateson/semantic-release-config": "^1.0.0",
+    "babel-eslint": "9.x",
+    "eslint": "5.x",
+    "eslint-config-prettier": "^4.0.0",
+    "eslint-config-react-app": "^3.0.8",
+    "eslint-plugin-flowtype": "^2.x",
+    "eslint-plugin-import": "2.x",
+    "eslint-plugin-jsx-a11y": "6.x",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "1.x",
     "husky": "^1.3.1",
+    "lint-staged": "^8.1.4",
+    "prettier": "^1.16.4",
     "semantic-release": "^15.13.3"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "eslint --fix .",
+    "test": "eslint --fix . && jest",
     "release": "semantic-release"
   },
   "peerDependencies": {
@@ -45,10 +45,15 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-hooks": "1.x",
+    "cpy": "^7.0.1",
     "husky": "^1.3.1",
+    "install-local": "^1.0.0",
+    "jest": "^24.1.0",
     "lint-staged": "^8.1.4",
     "prettier": "^1.16.4",
-    "semantic-release": "^15.13.3"
+    "semantic-release": "^15.13.3",
+    "shelljs": "^0.8.3",
+    "tmp": "^0.0.33"
   },
   "release": {
     "extends": "@jbateson/semantic-release-config"


### PR DESCRIPTION
I noticed problems with relying on deps being installed: eslint has trouble with transitive deps and the common eslint configs all adopt this approach.

To make this more robust, I added an integration test that actually reads from the package.json and installs the peer deps required, in the same way that a user would.